### PR TITLE
Syntax Update

### DIFF
--- a/content/docs/theming/class.md
+++ b/content/docs/theming/class.md
@@ -28,10 +28,10 @@ Here's an example of how to use `innerClass` with a [DataSearch](search-componen
 ```js
 <data-search
     ...
-    :innerClass=`{
+    :innerClass="{
         title: 'text-title',
         input: 'text-input'
-    }`
+    }"
 />
 ```
 
@@ -56,10 +56,10 @@ In order for your classes to overwrite the default classes of ReactiveSearch com
 ```js
 <data-search
     ...
-    :innerClass=`{
+    :innerClass="{
         title: 'text-title',
         input: 'text-input'
-    }`
+    }"
     class="text-field"
 />
 ```


### PR DESCRIPTION
The current syntax of injecting css in vue components is mentioned below:

```
  :innerClass=`{
        title: 'text-title',
        input: 'text-input'
    }`
```

but it's not working, I tried replacing ` ` with "" and it is working so I am updating readme modified syntax. i.e 

```
  :innerClass="{
        title: 'text-title',
        input: 'text-input'
    }"
```

